### PR TITLE
fix: hydrate correctly on loader suspend

### DIFF
--- a/.changeset/lazy-turtles-fail.md
+++ b/.changeset/lazy-turtles-fail.md
@@ -1,0 +1,5 @@
+---
+"solid-relay": patch
+---
+
+fix: hydrate correctly on loader suspend


### PR DESCRIPTION
Reported from https://github.com/ofarukaydin/solid-relay-hydration-bug

This fixes hydration issue of `createLazyLoadQuery` and derivatives that happen when the primitive itself is suspended due to no suspense wrapped on read.
The root cause was the `createResource` called conditionally, so it's fixed by always calling it and returning undefined instead.