### PR TITLE
fix: warn correctly when loading more pages

### DIFF
--- a/.changeset/thirty-trees-double.md
+++ b/.changeset/thirty-trees-double.md
@@ -1,0 +1,5 @@
+---
+"solid-relay": patch
+---
+
+fix: warn correctly when loading more pages

--- a/src/primitives/createPaginationFragment.ts
+++ b/src/primitives/createPaginationFragment.ts
@@ -305,10 +305,10 @@ function createLoadMore<TQuery extends OperationType, TKey extends KeyType>({
 
 			if (identifierInfo != null) {
 				const value = untrack(identifierValue);
-				if (typeof value === "string") {
+				if (typeof value !== "string") {
 					console.warn(
 						"Relay: Expected result to have a string  " +
-							`\`${identifierInfo.identifierField}\` in order to refetch, got \`${identifierValue}\`.`,
+							`\`${identifierInfo.identifierField}\` in order to refetch, got \`${value}\`.`,
 					);
 				}
 				paginationVariables[identifierInfo.identifierQueryVariableName] = value;


### PR DESCRIPTION
Fixes this
<img width="648" alt="스크린샷 2025-04-18 오후 7 56 19" src="https://github.com/user-attachments/assets/463d913d-e9f7-4f75-8492-fe6988b37e3f" />
