### PR TITLE
fix!: drop support for async preloaded queries

### DIFF
--- a/.changeset/silver-cases-heal.md
+++ b/.changeset/silver-cases-heal.md
@@ -1,0 +1,5 @@
+---
+"solid-relay": patch
+---
+
+fix!: drop support for async preloaded queries


### PR DESCRIPTION
This was breaking preloaded queries with variables