### PR TITLE
feat: re-add support for async preloaded queries

### DIFF
--- a/.changeset/hungry-ideas-chew.md
+++ b/.changeset/hungry-ideas-chew.md
@@ -1,0 +1,5 @@
+---
+"solid-relay": patch
+---
+
+feat: re-add support for async preloaded queries

--- a/src/utils/createMemoOperationDescriptor.ts
+++ b/src/utils/createMemoOperationDescriptor.ts
@@ -13,20 +13,24 @@ import { type MaybeAccessor, access } from "./access";
 
 export function createMemoOperationDescriptor(
 	gqlQuery: MaybeAccessor<GraphQLTaggedNode>,
-	variables: MaybeAccessor<Variables>,
+	variables: MaybeAccessor<Variables | undefined>,
 	cacheConfig?: MaybeAccessor<CacheConfig | undefined>,
-): Accessor<OperationDescriptor> {
+): Accessor<OperationDescriptor | undefined> {
 	const memoizedVariables = createMemo(() => access(variables), undefined, {
 		equals: dequal,
 	});
 	const memoizedCacheConfig = createMemo(() => access(cacheConfig), undefined, {
 		equals: dequal,
 	});
-	return createMemo(() =>
-		createOperationDescriptor(
+
+	return createMemo(() => {
+		const variables = memoizedVariables();
+		if (!variables) return;
+
+		return createOperationDescriptor(
 			getRequest(access(gqlQuery)),
-			memoizedVariables(),
+			variables,
 			memoizedCacheConfig(),
-		),
-	);
+		);
+	});
 }


### PR DESCRIPTION
Turns out `query` from Solid Router sometimes returns Promises even when the function is synchronous, so we should support async preloaded queries anyways to support ideal patterns.