### PR TITLE
feat: auto dispose queryRefs in `createPreloadedQuery()`

### DIFF
--- a/.changeset/bitter-corners-pay.md
+++ b/.changeset/bitter-corners-pay.md
@@ -1,0 +1,5 @@
+---
+"solid-relay": minor
+---
+
+feat: auto dispose queryRefs in `createPreloadedQuery()`

--- a/src/primitives/createPreloadedQuery.ts
+++ b/src/primitives/createPreloadedQuery.ts
@@ -4,7 +4,7 @@ import {
 	__internal,
 	getRequest,
 } from "relay-runtime";
-import { createResource } from "solid-js";
+import { createEffect, createResource, onCleanup } from "solid-js";
 import invariant from "tiny-invariant";
 import { useRelayEnvironment } from "../RelayEnvironment";
 import type { PreloadedQuery } from "../loadQuery";
@@ -29,6 +29,15 @@ export function createPreloadedQuery<TQuery extends OperationType>(
 		() => maybePreloaded.latest?.variables,
 		() => maybePreloaded.latest?.networkCacheConfig ?? undefined,
 	);
+
+	createEffect(() => {
+		const preloaded = maybePreloaded.latest;
+		if (preloaded) {
+			onCleanup(() => {
+				preloaded.controls?.value.dispose();
+			});
+		}
+	});
 
 	return createLazyLoadQueryInternal({
 		query: operation,


### PR DESCRIPTION
This PR enables `createPreloadedQuery()` to automatically dispose queryRefs of preloaded queries received on unmount.
While this makes it impossible to control the lifecycle of the preloaded queries more granularly, in most cases it greatly improves the usability of preloaded queries.