### PR TITLE
fix: resolve hydration flicker in queries

### DIFF
--- a/.changeset/four-windows-move.md
+++ b/.changeset/four-windows-move.md
@@ -1,0 +1,5 @@
+---
+"solid-relay": patch
+---
+
+fix: resolve hydration flicker in queries

--- a/src/primitives/createLazyLoadQuery.ts
+++ b/src/primitives/createLazyLoadQuery.ts
@@ -20,7 +20,11 @@ import {
 	createComputed,
 	createMemo,
 	createResource,
+	createSignal,
 	onCleanup,
+	Setter,
+	Signal,
+	untrack,
 } from "solid-js";
 import { reconcile } from "solid-js/store";
 import { getQueryCache, type QueryCacheEntry } from "../queryCache";
@@ -146,43 +150,64 @@ export function createLazyLoadQueryInternal<TQuery extends OperationType>(params
 					),
 				})
 			: undefined;
-		const [resource] = createResource(
+
+		type RecursiveResult = {
+			value: GraphQLResponse;
+			next: Promise<RecursiveResult>;
+		} | null;
+
+		const [resource] = createResource<RecursiveResult, Observable<GraphQLResponse>>(
 			() => shouldFetch && params.fetchObservable(),
 			async (observable) => {
 				subscriptionTarget = observable;
-				const stream = new ReadableStream<GraphQLResponse>({
-					start(controller) {
-						observable.subscribe({
-							next(response) {
-								controller.enqueue(response);
-							},
-							error(error: unknown) {
-								controller.error(error);
-							},
-							complete() {
-								controller.close();
-							},
-						});
+
+				let pr = Promise.withResolvers<RecursiveResult>();
+				observable.subscribe({
+					next(response) {
+						const nextPr = Promise.withResolvers<RecursiveResult>();
+						pr.resolve({ value: response, next: nextPr.promise });
+						pr = nextPr;
+					},
+					error(error: unknown) {
+						pr.reject(error);
+					},
+					complete() {
+						pr.resolve(null);
 					},
 				});
-				await observable.toPromise();
-				return stream;
+				return await pr.promise;
 			},
 			{
 				deferStream: params.deferStream,
-				onHydrated(operation, { value }) {
-					if (!operation || !value) return;
+				storage(init) {
+					let hydrated = false;
+					const [value, setValue] = createSignal(init);
 
-					void (async () => {
-						try {
-							for await (const response of value.values()) {
-								replaySubject.next(response);
+					return [
+						value,
+						(next: Setter<RecursiveResult | undefined>) => {
+							const current = untrack(value);
+							const nextValue = typeof next === "function" ? next(current) : next;
+
+							if (!hydrated) {
+								void (async () => {
+									let result = nextValue;
+									try {
+										while (result) {
+											replaySubject.next(result.value);
+											result = await result.next;
+										}
+										replaySubject.complete();
+									} catch (error) {
+										replaySubject.error(error instanceof Error ? error : new Error(String(error)));
+									}
+								})();
+								hydrated = true;
 							}
-							replaySubject.complete();
-						} catch (error) {
-							replaySubject.error(error instanceof Error ? error : new Error(String(error)));
-						}
-					})();
+
+							setValue(() => nextValue);
+						},
+					] as Signal<RecursiveResult | undefined>;
 				},
 			},
 		);

--- a/tests/ssr/createLazyLoadQuery.test.ssr.tsx
+++ b/tests/ssr/createLazyLoadQuery.test.ssr.tsx
@@ -103,7 +103,7 @@ describe("streaming SSR", () => {
 		});
 	});
 
-	describe.skip("flicker", () => {
+	describe("flicker", () => {
 		it("no flicker happens", async () => {
 			const { testRunId, url } = await commands.startSsrTestRun("createLazyLoadQuery/Flicker");
 			const frame = mountTestRunFrame(url);

--- a/tests/ssr/createLazyLoadQuery.test.ssr.tsx
+++ b/tests/ssr/createLazyLoadQuery.test.ssr.tsx
@@ -47,4 +47,95 @@ describe("streaming SSR", () => {
 		await expect.element(frame.getByTestId("name")).not.toBeInTheDocument();
 		await expect.element(frame.getByTestId("error")).toHaveTextContent("HTTP Error");
 	});
+
+	describe("parallel", () => {
+		it("renders both queries independently", async () => {
+			const { testRunId, url } = await commands.startSsrTestRun("createLazyLoadQuery/Parallel");
+			const frame = mountTestRunFrame(url);
+			onTestFailed(() => commands.stopSsrTestRun({ testRunId }));
+
+			await expect.element(frame.getByText("Fallback a")).toBeInTheDocument();
+			await expect.element(frame.getByText("Fallback b")).toBeInTheDocument();
+			await expect.element(frame.getByTestId("a")).not.toBeInTheDocument();
+			await expect.element(frame.getByTestId("b")).not.toBeInTheDocument();
+
+			await commands.sendSsrTestRunChunk({
+				testRunId,
+				fetchCount: 0,
+				chunk: {
+					data: {
+						node: {
+							__typename: "User",
+							id: "1",
+							name: "Alice",
+						},
+					},
+				},
+			});
+			await commands.completeSsrTestRunQuery({ testRunId, fetchCount: 0 });
+
+			await expect.element(frame.getByText("Fallback a")).not.toBeInTheDocument();
+			await expect.element(frame.getByText("Fallback b")).toBeInTheDocument();
+			await expect.element(frame.getByTestId("a")).toHaveTextContent("Hello Alice");
+			await expect.element(frame.getByTestId("error")).not.toBeInTheDocument();
+
+			await commands.sendSsrTestRunChunk({
+				testRunId,
+				fetchCount: 1,
+				chunk: {
+					data: {
+						node: {
+							__typename: "User",
+							id: "2",
+							name: "Bob",
+						},
+					},
+				},
+			});
+			await commands.completeSsrTestRunQuery({ testRunId, fetchCount: 1 });
+			await commands.stopSsrTestRun({ testRunId });
+
+			await expect.element(frame.getByText("Fallback a")).not.toBeInTheDocument();
+			await expect.element(frame.getByText("Fallback b")).not.toBeInTheDocument();
+			await expect.element(frame.getByTestId("a")).toHaveTextContent("Hello Alice");
+			await expect.element(frame.getByTestId("b")).toHaveTextContent("Goodbye Bob");
+			await expect.element(frame.getByTestId("error")).not.toBeInTheDocument();
+		});
+	});
+
+	describe.skip("flicker", () => {
+		it("no flicker happens", async () => {
+			const { testRunId, url } = await commands.startSsrTestRun("createLazyLoadQuery/Flicker");
+			const frame = mountTestRunFrame(url);
+			onTestFailed(() => commands.stopSsrTestRun({ testRunId }));
+
+			await expect.element(frame.getByText("Fallback")).toBeInTheDocument();
+			await expect.element(frame.getByTestId("name")).not.toBeInTheDocument();
+
+			await commands.sendSsrTestRunChunk({
+				testRunId,
+				chunk: {
+					data: {
+						node: {
+							__typename: "User",
+							id: "1",
+							name: "Alice",
+						},
+					},
+				},
+			});
+			await commands.stopSsrTestRun({ testRunId });
+
+			await expect.element(frame.getByText("Fallback")).not.toBeInTheDocument();
+			await expect.element(frame.getByTestId("name")).toHaveTextContent("no error Alice server");
+			await expect.element(frame.getByTestId("error")).not.toBeInTheDocument();
+
+			await expect
+				.element(frame.getByTestId("query-hydrated"))
+				.toHaveTextContent("Query Hydrated: true");
+			await frame.getByTestId("rerender").click();
+			await expect.element(frame.getByTestId("name")).toHaveTextContent("no error Alice browser");
+			await expect.element(frame.getByTestId("error")).not.toBeInTheDocument();
+		});
+	});
 });

--- a/tests/ssr/harness/SsrApp.tsx
+++ b/tests/ssr/harness/SsrApp.tsx
@@ -22,6 +22,7 @@ export function SsrApp<
 	TSetupSuite extends SetupSuite<TSetupFile>,
 	TSetupId extends SetupId<TSetupFile, TSetupSuite> = SetupId<TSetupFile, TSetupSuite>,
 >(props: { origin: string; testRunId: string; setupId: TSetupId }) {
+	let fetchCount = 0;
 	const environment = new Environment({
 		store: new Store(new RecordSource(), { gcReleaseBufferSize: 0 }),
 		network: {
@@ -29,7 +30,10 @@ export function SsrApp<
 				Observable.create((sink) => {
 					(async () => {
 						const response = await fetch(
-							new URL(`/__ssr/graphql?testRunId=${props.testRunId}`, props.origin),
+							new URL(
+								`/__ssr/graphql?testRunId=${props.testRunId}&fetchCount=${fetchCount++}`,
+								props.origin,
+							),
 						);
 						if (!response.ok) throw new Error("HTTP Error");
 

--- a/tests/ssr/harness/vitest-browser-commands.d.ts
+++ b/tests/ssr/harness/vitest-browser-commands.d.ts
@@ -10,8 +10,10 @@ declare module "vitest/browser" {
 		sendSsrTestRunChunk: (
 			input: {
 				testRunId: string;
+				fetchCount?: number;
 			} & ({ chunk: GraphQLSingularResponse; error?: never } | { chunk?: never; error: Error }),
 		) => Promise<void>;
+		completeSsrTestRunQuery: (input: { testRunId: string; fetchCount?: number }) => Promise<void>;
 		stopSsrTestRun: (input: { testRunId: string }) => Promise<void>;
 	}
 }

--- a/tests/ssr/harness/vitest.ts
+++ b/tests/ssr/harness/vitest.ts
@@ -7,7 +7,7 @@ const testRuns = new Map<
 	string,
 	{
 		setupId: SetupId;
-		replaySubject: ReplaySubject<GraphQLSingularResponse>;
+		replaySubjects: ReplaySubject<GraphQLSingularResponse>[];
 	}
 >();
 
@@ -33,8 +33,10 @@ export function ssrTestPlugin(): Plugin {
 					res.setHeader("cache-control", "no-store");
 
 					if (requestUrl.pathname === "/__ssr/graphql") {
+						const fetchCount = Number(requestUrl.searchParams.get("fetchCount") ?? 0);
 						let isStreaming: boolean | undefined;
-						const subscription = testRun.replaySubject.subscribe({
+						const subscription = (testRun.replaySubjects[fetchCount] ??=
+							new ReplaySubject()).subscribe({
 							next(response) {
 								if (isStreaming == null) {
 									isStreaming = response.extensions?.is_final === false;
@@ -92,7 +94,7 @@ export function ssrTestPlugin(): Plugin {
 
 const startSsrTestRun: BrowserCommand<[SetupId]> = async (_, setupId) => {
 	const id = `ssr-test-${crypto.randomUUID()}`;
-	testRuns.set(id, { setupId, replaySubject: new ReplaySubject() });
+	testRuns.set(id, { setupId, replaySubjects: [] });
 	return {
 		testRunId: id,
 		url: `/__ssr?testRunId=${encodeURIComponent(id)}`,
@@ -103,6 +105,7 @@ const sendSsrTestRunChunk: BrowserCommand<
 	[
 		{
 			testRunId: string;
+			fetchCount?: number;
 		} & ({ chunk: GraphQLSingularResponse; error?: never } | { chunk?: never; error: Error }),
 	]
 > = async (_ctx, input) => {
@@ -110,19 +113,29 @@ const sendSsrTestRunChunk: BrowserCommand<
 	if (!testRun) {
 		throw new Error(`Unknown test run '${input.testRunId}'`);
 	}
-	if (input.chunk) testRun.replaySubject.next(input.chunk);
-	else testRun.replaySubject.error(input.error);
+	const replaySubject = (testRun.replaySubjects[input.fetchCount ?? 0] ??= new ReplaySubject());
+	if (input.chunk) replaySubject.next(input.chunk);
+	else replaySubject.error(input.error);
+};
+
+const completeSsrTestRunQuery: BrowserCommand<
+	[{ testRunId: string; fetchCount?: number }]
+> = async (_ctx, input) => {
+	const testRun = testRuns.get(input.testRunId);
+	if (!testRun) return;
+	testRun.replaySubjects[input.fetchCount ?? 0].complete();
 };
 
 const stopSsrTestRun: BrowserCommand<[{ testRunId: string }]> = async (_ctx, input) => {
 	const testRun = testRuns.get(input.testRunId);
 	if (!testRun) return;
-	testRun.replaySubject.complete();
+	for (const subject of testRun.replaySubjects) subject.complete();
 	testRuns.delete(input.testRunId);
 };
 
 export const ssrBrowserCommands = {
 	startSsrTestRun,
 	sendSsrTestRunChunk,
+	completeSsrTestRunQuery,
 	stopSsrTestRun,
 };

--- a/tests/ssr/setups/createLazyLoadQuery.tsx
+++ b/tests/ssr/setups/createLazyLoadQuery.tsx
@@ -1,7 +1,10 @@
 import { graphql } from "relay-runtime";
-import { ErrorBoundary, Suspense } from "solid-js";
+import { createSignal, ErrorBoundary, Show, Suspense } from "solid-js";
 import { createLazyLoadQuery } from "solid-relay";
+import { createLazyLoadQuerySsrFlickerTestQuery } from "./__generated__/createLazyLoadQuerySsrFlickerTestQuery.graphql";
 import type { createLazyLoadQuerySsrMainTestQuery } from "./__generated__/createLazyLoadQuerySsrMainTestQuery.graphql";
+import { createLazyLoadQuerySsrParallelTestAQuery } from "./__generated__/createLazyLoadQuerySsrParallelTestAQuery.graphql";
+import { createLazyLoadQuerySsrParallelTestBQuery } from "./__generated__/createLazyLoadQuerySsrParallelTestBQuery.graphql";
 
 export function Main() {
 	const data = createLazyLoadQuery<createLazyLoadQuerySsrMainTestQuery>(
@@ -22,6 +25,109 @@ export function Main() {
 		<ErrorBoundary fallback={(err) => <h1 data-testid="error">{err.message}</h1>}>
 			<Suspense fallback="Fallback">
 				<h1 data-testid="name">{data()?.node?.name}</h1>
+			</Suspense>
+		</ErrorBoundary>
+	);
+}
+
+export function Parallel() {
+	const a = createLazyLoadQuery<createLazyLoadQuerySsrParallelTestAQuery>(
+		graphql`
+			query createLazyLoadQuerySsrParallelTestAQuery {
+				node(id: "1") {
+					id
+					... on User {
+						name
+					}
+				}
+			}
+		`,
+		{},
+	);
+	const b = createLazyLoadQuery<createLazyLoadQuerySsrParallelTestBQuery>(
+		graphql`
+			query createLazyLoadQuerySsrParallelTestBQuery {
+				node(id: "2") {
+					id
+					... on User {
+						name
+					}
+				}
+			}
+		`,
+		{},
+	);
+
+	return (
+		<ErrorBoundary fallback={(err) => <h1 data-testid="error">{err.message}</h1>}>
+			<Suspense
+				fallback={
+					<>
+						<span>Fallback</span> <span>a</span>
+					</>
+				}
+			>
+				<Show when={a()?.node?.name}>{(name) => <h1 data-testid="a">{`Hello ${name()}`}</h1>}</Show>
+			</Suspense>
+			<Suspense
+				fallback={
+					<>
+						<span>Fallback</span> <span>b</span>
+					</>
+				}
+			>
+				<Show when={b()?.node?.name}>
+					{(name) => <h1 data-testid="b">{`Goodbye ${name()}`}</h1>}
+				</Show>
+			</Suspense>
+		</ErrorBoundary>
+	);
+}
+
+export function Flicker() {
+	const data = createLazyLoadQuery<createLazyLoadQuerySsrFlickerTestQuery>(
+		graphql`
+			query createLazyLoadQuerySsrFlickerTestQuery {
+				node(id: "1") {
+					id
+					... on User {
+						name
+					}
+				}
+			}
+		`,
+		{},
+	);
+	let error = "no error";
+	const env = typeof window === "object" ? "browser" : "server";
+	const [queryHydrated, setQueryHydrated] = createSignal(false);
+	const [track, rerender] = createSignal(undefined, { equals: false });
+
+	return (
+		<ErrorBoundary fallback={(err) => <h1 data-testid="error">{err.message}</h1>}>
+			<Suspense fallback="Fallback">
+				<h1 data-testid="name">
+					{(() => {
+						track();
+						const name = data()?.node?.name;
+						if (env === "browser") {
+							if (!name) {
+								// client should never try render without data
+								error = "client render without data";
+							} else {
+								// server rendered nodes win over client hydrate-rendered nodes
+								// so we need to rerender after hydration
+								// this mutation notifies the test runner to rerender the component
+								queueMicrotask(() => setQueryHydrated(true));
+							}
+						}
+						return `${error} ${name} ${env}`;
+					})()}
+				</h1>
+				<h2 data-testid="query-hydrated">Query Hydrated: {String(queryHydrated())}</h2>
+				<button data-testid="rerender" onClick={() => rerender()}>
+					Rerender text
+				</button>
 			</Suspense>
 		</ErrorBoundary>
 	);


### PR DESCRIPTION
The `onHydrated` callback of `createResource`, which `createLazyLoadQueryInternal` previously relied on to stream the query payloads, runs after the synchronous hydration process ends [due to being called inside a `queueMicrotask` call](https://github.com/solidjs/solid/blob/878f94a0310c44a0cb5d14e8dd016f7b5e609ff0/packages/solid/src/reactive/signal.ts#L646). This resulted in having no data inside the Relay store during the synchronous hydration process, which then resulted in occasional flickers.

This PR fixes the flicker issue by utilizing `storage` option of `createResource`, which provides synchronous access to the hydration process.